### PR TITLE
Ignore only top-level project-specific folders in `.gitignore`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,9 @@
 # Edit at https://www.toptal.com/developers/gitignore?templates=linux,osx,git,visualstudiocode,python,jupyternotebooks
 
 # Project Specific
-wandb/
-models/
-best_models/
+/wandb/
+/models/
+/best_models/
 
 ### Git ###
 # Created by git for backups. To disable backups in Git:


### PR DESCRIPTION
I planned to create a `conplex_dti/web/models` folder for the web application's database models, but the current `.gitignore` ignores that folder. I assume that these three entries in `.gitignore` are intended for top-level folders with the corresponding names, so I updated the file to match that.