### PR TITLE
fix: link to correct readthedocs from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
  - [Homepage](http://conplex.csail.mit.edu)
- - [Documentation](https://d-script.readthedocs.io/en/main/)
+ - [Documentation](https://conplex.readthedocs.io/en/latest/)
 
 ## Abstract
 


### PR DESCRIPTION
## Description

The README doc link points to https://d-script.readthedocs.io/en/main/

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/samsledje/conplex-dti/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/samsledje/conplex-dti/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
